### PR TITLE
Support newer react versions that deprecated PropTypes.

### DIFF
--- a/HyperlinkedText.js
+++ b/HyperlinkedText.js
@@ -2,7 +2,8 @@
  * @providesModule react-native-hyperlinked-text
  */
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
 	View,
 	Text,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "react-native", "hyperlink", "hyperlinks", "regex", "links"
   ],
   "dependencies": {
+    "prop-types": "^15.6.0",
     "ramda": "^0.24.1"
   },
   "description": "Text component for React Native with regex defined hyperlinks",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "HyperlinkedText.js",
   "devDependencies": {},
   "peerDependencies": {
-    "react-native": "^0.46.1"
+    "react-native": ">=0.46.1"
   },
   "scripts": {
     "test": "mocha --reporter spec"


### PR DESCRIPTION
In newer versions of react, `react.PropTypes` does not exist anymore as it is a separate package now. Added it and changed in code.