### PR TITLE
Fix TS typing of style props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,18 @@
 declare module "react-native-hyperlinked-text" {
 
-    import {TextStyle} from "react-native";
+    import {StyleProp, TextStyle} from "react-native";
 
     export interface ILinkDef {
         regex: RegExp;
-        style?: TextStyle;
+        style?: StyleProp<TextStyle>;
         replaceText?: (orig: string, text: string, url: string) => string;
         onPress?: (orig: string, text: string, url: string) => void;
         noPress?: boolean;
     }
 
     interface IProps {
-        style?: TextStyle;
-        linkStyle?: TextStyle;
+        style?: StyleProp<TextStyle>;
+        linkStyle?: StyleProp<TextStyle>;
         linkDefs?: ILinkDef[];
         onLinkPress?: (text: string) => void;
     }


### PR DESCRIPTION
This change allows us to pass multiple styles to the component, as explained e.g. here:
https://spin.atomicobject.com/2018/06/02/custom-components-react-native/

(This is exactly how React Native's own `Text` component is typed as well.)