### PR TITLE
Declare regexResult to crash fix

### DIFF
--- a/HyperlinkedText.js
+++ b/HyperlinkedText.js
@@ -44,6 +44,7 @@ export default class HyperlinkedText extends Component {
     const regex = linkDef.regex;
     regex.lastIndex = 0; // reset the regex in case it was used before
     let matches = [];
+    let regexResult;
     while ((regexResult = regex.exec(text)) !== null) {
       matches.push({
        text: regexResult[0],


### PR DESCRIPTION
Add regexResult declaration to prevent crash.

![Screenshot_20230313_154249_Brasil Bitcoin](https://user-images.githubusercontent.com/35431617/224799735-047ca217-07fc-4ac7-8e20-1d109ecf82d8.jpg)
